### PR TITLE
ffmpeg api update + arguments fix on launching emulator

### DIFF
--- a/emulator.c
+++ b/emulator.c
@@ -75,8 +75,8 @@ int emulator_exec( struct game *game ) {
 #endif
 
 #ifdef __unix__
-	// ensuring that argv[0] from the callee's perspective is the executable name,
-	// so that the first param doesn't get swallowed
+	/* ensuring that argv[0] from the callee's perspective is the executable name,
+	 * so that the first param doesn't get swallowed */
 	params[count++] = game->emulator->executable;
 #endif
 

--- a/emulator.c
+++ b/emulator.c
@@ -74,6 +74,12 @@ int emulator_exec( struct game *game ) {
 	char cmdline[CONFIG_MAX_CMD_LENGTH];
 #endif
 
+#ifdef __unix__
+	// ensuring that argv[0] from the callee's perspective is the executable name,
+	// so that the first param doesn't get swallowed
+	params[count++] = game->emulator->executable;
+#endif
+
 	if( game->emulator && game->emulator->executable ) {
 		param = game->emulator->params;
 		while( param ) {

--- a/location.c
+++ b/location.c
@@ -203,7 +203,7 @@ int location_get_match( const char *type, const char *filename, char *path ) {
 					if( strncasecmp( dentry->d_name, search, strlen(search) ) == 0 ) {
 						snprintf( path, CONFIG_FILE_NAME_LENGTH, "%s/%s", location->directory, dentry->d_name );
 #endif
-						found = 1;
+						found++;
 					}
 				}
 				closedir( dir );
@@ -212,8 +212,12 @@ int location_get_match( const char *type, const char *filename, char *path ) {
 		}
 	}
 
-	if( found )
+	if( found ) {
+		if ( found > 1 )
+			printf( "Warning: multiple %s assets match \"%s\", picked \"%s\"\n", type, filename, path ); 
+			
 		return 0;
+	}
 	
 	strcpy( path, "" );
 	return -1;


### PR DESCRIPTION
Hi Steve, 

This pull request contains the fixes I made to have cabrio working on my system (xubuntu), the arguments issue (where the first argument was being swallowed) was a real problem I faced. For example, in an emulator where no command line parameters are defined (say snes9x where the emulator config is in a separate file), the rom path itself was being swallowed and the emulator would launch in default mode.

I had sent you these changes as patches by email, but github just makes it waaay more convenient to do so in a trackable manner!

I hope the style matches your expectations, let me know if you need me to change anything

Cheers!
Tim.
