### PR TITLE
Throw away hat "center" events to silence warnings

### DIFF
--- a/sdl_wrapper.c
+++ b/sdl_wrapper.c
@@ -74,6 +74,8 @@ void sdl_swap( void ) {
 
 int sdl_hat_dir_value( int direction ) {
 	switch( direction ) {
+		case SDL_HAT_CENTERED:
+			break;
 		case SDL_HAT_UP:
 			return DIR_UP;
 			break;


### PR DESCRIPTION
Whenever a hat event ends (the user releases the button) the controller sends a SDL_HAT_CENTERED event which caused cabrio to print a warning every time the user released a hat direction.
