### PR TITLE
Pass emulator and game arguments in the order they were provided

### DIFF
--- a/config.c
+++ b/config.c
@@ -633,6 +633,7 @@ int config_read_game_categories( xmlNode *node, struct config_game *game ) {
 }
 
 int config_read_game_params( xmlNode *node, struct config_game *game ) {
+	struct config_param *previous = NULL;
 	while( node ) {
 		if( node->type == XML_ELEMENT_NODE ) {
 			if( strcmp( (char*)node->name, tag_param ) == 0 ) {
@@ -640,8 +641,13 @@ int config_read_game_params( xmlNode *node, struct config_game *game ) {
 				if( param ) {
 					memset( param, 0, sizeof(struct config_param ) );
 					config_read_param( node->children, param );
-					param->next = game->params;
-					game->params = param;
+					if( previous != NULL ) {
+						previous->next = param;
+					}
+					if( game->params == NULL ) {
+						game->params = param;
+					}
+					previous = param;
 				}
 				else {
 					fprintf( stderr, warn_alloc, tag_param );

--- a/config.c
+++ b/config.c
@@ -402,6 +402,7 @@ int config_read_param( xmlNode *node, struct config_param *param ) {
 }
 
 int config_read_emulator_params( xmlNode *node, struct config_emulator *emulator ) {
+	struct config_param *previous = NULL;
 	while( node ) {
 		if( node->type == XML_ELEMENT_NODE ) {
 			if( strcmp( (char*)node->name, tag_param ) == 0 ) {
@@ -409,8 +410,13 @@ int config_read_emulator_params( xmlNode *node, struct config_emulator *emulator
 				if( param ) {
 					memset( param, 0, sizeof(struct config_param ) );
 					config_read_param( node->children, param );
-					param->next = emulator->params;
-					emulator->params = param;
+					if( previous != NULL ) {
+						previous->next = param;
+					}
+					if( emulator->params == NULL ) {
+						emulator->params = param;
+					}
+					previous = param;
 				}
 				else {
 					fprintf( stderr, warn_alloc, tag_param );


### PR DESCRIPTION
When reading the config file the emulator and game command line arguments were always reversed with respect to how they were written in the XML because of the way the linked list was generated. 

This patch constructs the linked list in the same order as the arguments were written out in the XML.
